### PR TITLE
Update to 0.13.7 scriptclass dependency to fix break in publish-module

### DIFF
--- a/PoshGraph-SDK.psd1
+++ b/PoshGraph-SDK.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.1.1'
+ModuleVersion = '0.1.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -66,7 +66,7 @@ ScriptsToProcess = @('./src/graph-sdk.ps1')
 # FormatsToProcess = @()
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-NestedModules = @(@{ModuleName='scriptclass';ModuleVersion='0.13.6';Guid='9b0f5599-0498-459c-9a47-125787b1af19'})
+NestedModules = @(@{ModuleName='scriptclass';ModuleVersion='0.13.7';Guid='9b0f5599-0498-459c-9a47-125787b1af19'})
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @()
@@ -157,6 +157,10 @@ PrivateData = @{
 
         # A URL to an icon representing this module.
         IconUri = 'https://raw.githubusercontent.com/adamedx/poshgraph-sdk/master/assets/PoshGraphIcon.png'
+
+        # Adds pre-release to the patch version according to the conventions of https://semver.org/spec/v1.0.0.html
+        # Requires PowerShellGet 1.6.0 or greater
+        # Prerelease = '-preview'
 
         # ReleaseNotes of this module
         # ReleaseNotes = ''

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,14 @@
 
 ## To-do items -- prioritized
 
-* Refactor into posh-graph core sdk and poshgraph ux
+* Add app creation
+* Add app enumeration
+* Add app updating
+* Release
+
+* Add app-only mode
+* Release
+
 * Clean up parse methods in GraphUtilities
 * Investigate console.writeline background thread
 * Coding standards -- SOLID, casing, method call syntax
@@ -29,18 +36,8 @@
 * fix parent issues in public segment
 
 * Add auto-complete for scopes
-* Add auto-complete for ggu
-* Add auto-complete for gls
 
 * Release
-
-* Add app creation
-* Add app enumeration
-* Add app updating
-
-* Release
-
-* Add app-only mode
 
 * Samples
 * Bugfixes
@@ -234,6 +231,7 @@
 * Update get-graphitem to give gls authorization warnings.
 * Fix publishmoduletodev to use module publishing rather than nuget
 * Fix token refresh
+* Refactor into posh-graph core sdk and poshgraph ux
 
 ### Postponed
 

--- a/poshgraph-sdk.nuspec
+++ b/poshgraph-sdk.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2018</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="scriptclass" version="0.13.6" />
+      <dependency id="scriptclass" version="0.13.7" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
### Description

Dependency on updated version of scriptclass (0.13.7) that fixes a build break in publish-module caused by scriptclass

### Dependency changes

scriptclass dependency updated to 0.13.7.

### Checklist

- [ ] All project tests pass successfully
