### PR TITLE
Auth protocol, connection and national cloud improvements

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,4 @@
 
 - [ ] New test coverage was added for the new functionality
 - [ ] All project tests pass successfully
-- [ ] All commits have a sign-off for the Developer Certificate of Origin. See <https://github.com/adamedx/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
+- [ ] All commits have a sign-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

--- a/PoshGraph-SDK.psd1
+++ b/PoshGraph-SDK.psd1
@@ -160,7 +160,7 @@ PrivateData = @{
 
         # Adds pre-release to the patch version according to the conventions of https://semver.org/spec/v1.0.0.html
         # Requires PowerShellGet 1.6.0 or greater
-        # Prerelease = '-preview'
+        Prerelease = '-preview'
 
         # ReleaseNotes of this module
         ReleaseNotes = @"

--- a/PoshGraph-SDK.psd1
+++ b/PoshGraph-SDK.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.1.3'
+ModuleVersion = '0.2.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PoshGraph-SDK.psd1
+++ b/PoshGraph-SDK.psd1
@@ -163,7 +163,21 @@ PrivateData = @{
         # Prerelease = '-preview'
 
         # ReleaseNotes of this module
-        # ReleaseNotes = ''
+        ReleaseNotes = @"
+# PoshGraph Release Notes
+
+## New features
+
+### Cmdlet features
+
+* Connect-Graph cmdlet: -Reconnect option to reconnect a previously disconnected Graph
+* Connect-Graph cmdlet: -ScopeNames supported with -Reconnect for permission elevation scenarios
+* Connect-Graph is now deterministic -- no longer based on context unless you specify -Reconnect
+* Disconnect-Graph is now deterministic -- it removes cached tokens so that subsequent connection attempts behave as if it's the very first attempt
+* New-GraphConnection cmdlet: -AuthProtocol option configures authentication protocol to overridde defaults if needed
+* New-GraphConnection cmdlet: -RedirectUri option allows the use of custom applications with a particular redirect URI
+* New-GraphConnection cmdlet: -TenantName option allows the use of custom non-converged applications that require the tenant (including 'organizations') to be specified during authentication
+"@
 
     } # End of PSData hashtable
 

--- a/PoshGraph-SDK.psd1
+++ b/PoshGraph-SDK.psd1
@@ -164,19 +164,34 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# PoshGraph Release Notes
+# PoshGraph-SDK 0.2.0 Release Notes
 
 ## New features
 
 ### Cmdlet features
 
-* Connect-Graph cmdlet: -Reconnect option to reconnect a previously disconnected Graph
-* Connect-Graph cmdlet: -ScopeNames supported with -Reconnect for permission elevation scenarios
-* Connect-Graph is now deterministic -- no longer based on context unless you specify -Reconnect
-* Disconnect-Graph is now deterministic -- it removes cached tokens so that subsequent connection attempts behave as if it's the very first attempt
-* New-GraphConnection cmdlet: -AuthProtocol option configures authentication protocol to overridde defaults if needed
-* New-GraphConnection cmdlet: -RedirectUri option allows the use of custom applications with a particular redirect URI
-* New-GraphConnection cmdlet: -TenantName option allows the use of custom non-converged applications that require the tenant (including 'organizations') to be specified during authentication
+* ``Connect-Graph`` cmdlet: ``-Reconnect`` option to reconnect a previously disconnected Graph
+* ``Connect-Graph`` cmdlet: ``-ScopeNames`` supported with -Reconnect for permission elevation scenarios
+* ``Connect-Graph`` is now deterministic -- no longer based on context unless you specify ``-Reconnect``
+* ``Disconnect-Graph`` is now deterministic -- it removes cached tokens so that subsequent connection attempts behave as if it's the very first attempt
+* ``New-GraphConnection`` cmdlet: ``-AuthProtocol`` option configures authentication protocol to overridde defaults if needed
+* ``New-GraphConnection`` cmdlet: ``-RedirectUri`` option allows the use of custom applications with a particular redirect URI
+* ``New-GraphConnection`` cmdlet: ``-TenantName`` option allows the use of custom non-converged applications that require the tenant (including 'organizations') to be specified during authentication
+
+### Library features
+
+* ``GraphIdentity`` now takes a ``TenantName`` argument to support v1 tenant-scoped applications
+* ``GraphIdentity`` exposes a ``GetUserInformation`` method to return data about the authenticated user (if any)
+* ``GraphEndpoint`` exposes a ``GetAuthUri`` method to return the URI for obtaining access tokens
+
+## Fixed defects
+
+* ``Get-GraphItem``, ``Invoke-GraphRequest`` were ignoring ``-Version`` option -- these commands could only access the Graph ``v1.0`` API version
+* National cloud support through ``-Cloud`` arguments now works in commands like ``Connect-Graph``, ``New-GraphConnection``, etc.
+* Fix ignored scopes when ``-ScopeNames`` was specified with ``Connect-Graph``
+* Fix over-specification of parameters for ``New-GraphConnection`` due to missing default parameterset
+* Fix exception in ``Disconnect-Graph`` cmdlet due to call to removed method
+* 
 "@
 
     } # End of PSData hashtable

--- a/src/client/GraphApplication.ps1
+++ b/src/client/GraphApplication.ps1
@@ -23,12 +23,28 @@ ScriptClass GraphApplication {
     $AppId = strict-val [Guid]
     $Secret = $null
     $AuthType = ([GraphAppAuthType]::Delegated)
+    $RedirectUri = $null
 
-    function __initialize($appId = $null) {
+    function __initialize($appId = $null, $RedirectUri = $null) {
         $this.AppId = if ( $appId -ne $null ) {
+            if ( $RedirectUri ) {
+                throw [ArgumentException]::new("Redirect Uri must '$RedirectUri', it must be `$null since no AppId was specified")
+            }
             $appId
         } else {
             $::.Application.AppId
         }
+
+        $this.RedirectUri = if ( $RedirectUri ) {
+            $RedirectUri
+        } else {
+            __GetDefaultRedirectUri $this.AppId
+        }
+
+
+    }
+
+    function __GetDefaultRedirectUri($appId) {
+        'msal{0}://auth' -f $appId
     }
 }

--- a/src/client/GraphApplication.ps1
+++ b/src/client/GraphApplication.ps1
@@ -27,11 +27,12 @@ ScriptClass GraphApplication {
 
     function __initialize($appId = $null, $RedirectUri = $null) {
         $this.AppId = if ( $appId -ne $null ) {
+            $appId
+        } else {
             if ( $RedirectUri ) {
                 throw [ArgumentException]::new("Redirect Uri must '$RedirectUri', it must be `$null since no AppId was specified")
             }
-            $appId
-        } else {
+
             $::.Application.AppId
         }
 
@@ -40,8 +41,6 @@ ScriptClass GraphApplication {
         } else {
             __GetDefaultRedirectUri $this.AppId
         }
-
-
     }
 
     function __GetDefaultRedirectUri($appId) {

--- a/src/client/GraphConnection.ps1
+++ b/src/client/GraphConnection.ps1
@@ -33,6 +33,10 @@ ScriptClass GraphConnection {
         $this.Connected = $false
         $this.Status = [GraphConnectionStatus]::Online
 
+        if ( ! $identity ) {
+            throw 'how did this happen'
+        }
+
         if ( $this.GraphEndpoint.Type -eq ([GraphType]::MSGraph) ) {
             if ( $Identity -and ! $scopes ) {
                 throw "No scopes were specified, at least one scope must be specified"
@@ -78,7 +82,9 @@ ScriptClass GraphConnection {
 
     function Disconnect {
         if ( $this.connected ) {
-            $this.identity |=> ClearAuthentication
+            if ( $this.identity ) {
+                $this.identity |=> ClearAuthentication
+            }
             $this.connected = $false
         } else {
             throw "Cannot disconnect from Graph because connection is already disconnected."
@@ -90,11 +96,11 @@ ScriptClass GraphConnection {
     }
 
     static {
-        function NewSimpleConnection([GraphType] $graphType, [GraphCloud] $cloud = 'Public', [String[]] $ScopeNames, $anonymous = $false) {
+        function NewSimpleConnection([GraphType] $graphType, [GraphCloud] $cloud = 'Public', [String[]] $ScopeNames, $anonymous = $false, $tenantName = $null) {
             $endpoint = new-so GraphEndpoint $cloud $graphType
             $app = new-so GraphApplication
             $identity = if ( ! $anonymous ) {
-                new-so GraphIdentity $app $endpoint
+                new-so GraphIdentity $app $endpoint $tenantName
             }
 
             new-so GraphConnection $endpoint $identity $ScopeNames

--- a/src/client/GraphConnection.ps1
+++ b/src/client/GraphConnection.ps1
@@ -94,7 +94,7 @@ ScriptClass GraphConnection {
             $endpoint = new-so GraphEndpoint $cloud $graphType
             $app = new-so GraphApplication
             $identity = if ( ! $anonymous ) {
-                new-so GraphIdentity $app
+                new-so GraphIdentity $app $endpoint
             }
 
             new-so GraphConnection $endpoint $identity $ScopeNames

--- a/src/client/GraphConnection.ps1
+++ b/src/client/GraphConnection.ps1
@@ -33,10 +33,6 @@ ScriptClass GraphConnection {
         $this.Connected = $false
         $this.Status = [GraphConnectionStatus]::Online
 
-        if ( ! $identity ) {
-            throw 'how did this happen'
-        }
-
         if ( $this.GraphEndpoint.Type -eq ([GraphType]::MSGraph) ) {
             if ( $Identity -and ! $scopes ) {
                 throw "No scopes were specified, at least one scope must be specified"

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -40,6 +40,30 @@ ScriptClass GraphIdentity {
         $this.TenantName = $tenantName
     }
 
+    function GetUserInformation {
+        $authProtocol = $this.GraphEndPoint.AuthProtocol
+
+        $userId = $null
+        $scopes = $null
+
+        if ( $this.token ) {
+            if ( $authProtocol -eq ([GraphAuthProtocol]::v1) ) {
+                $userId = $this.token.UserInfo.DisplayableId
+                $scopes = $null
+            } elseif ( $authProtocol -eq ([GraphAuthProtocol]::v2) ) {
+                $userId = $this.token.User.DisplayableId
+                $scopes = $this.token.scopes
+            } else {
+                throw ("Unknown auth protocol '{0}'" -f $authProtocol)
+            }
+        }
+
+        @{
+            userId = $userId
+            scopes = $scopes
+        }
+    }
+
     function Authenticate($graphEndpoint, $scopes = $null) {
         if ( $this.token ) {
             $tokenTimeLeft = $this.token.expireson - [DateTime]::UtcNow

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -143,7 +143,7 @@ ScriptClass GraphIdentity {
         write-verbose "Attempting to get token for AAD Graph..."
         $adalAuthContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $graphEndpoint.Authentication
         $redirectUri = 'msal9825d80c-5aa0-42ef-bf13-61e12116704c://auth'
-
+ 
         $promptBehaviorValue = ([Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto)
 
         $promptBehavior = new-object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehaviorValue

--- a/src/cmdlets/Disconnect-Graph.ps1
+++ b/src/cmdlets/Disconnect-Graph.ps1
@@ -18,6 +18,5 @@ function Disconnect-Graph {
     [cmdletbinding()]
     param()
     $::.GraphContext |=> DisconnectCurrentConnection
-    __AutoConfigurePrompt ($::.GraphContext |=> GetCurrent)
 }
 

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -210,7 +210,7 @@ function Invoke-GraphRequest {
         }
     }
 
-    $tenantQualifiedVersionSegment = if ( $graphType -eq ([GraphType]::AADGraph ) ) {
+    $tenantQualifiedVersionSegment = if ( $graphType -eq ([GraphType]::AADGraph) ) {
         $graphConnection |=> Connect
         $graphConnection.Identity.Token.TenantId
     } else {

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -194,9 +194,13 @@ function Invoke-GraphRequest {
         }
     }
 
-    $apiVersion = if ( $uriInfo -and $uriInfo.GraphVersion ) {
+    $apiVersion = if ( $Version -ne $null -or $version.length -ne 0 ) {
+        write-verbose "Using version specified by caller: '$Version'"
+        $Version
+    } elseif ( $uriInfo -and $uriInfo.GraphVersion -and $uriInfo ) {
+        write-verbose "Using version from implied relative uri: '$($uriInfo.GraphVersion)'"
         $uriInfo.GraphVersion
-    } elseif ( $Version -eq $null -or $version.length -eq 0 ) {
+    } else {
         if ( $currentContext ) {
             write-verbose "Using context Graph version '$($currentContext.Version)'"
             $currentContext.Version
@@ -204,8 +208,6 @@ function Invoke-GraphRequest {
             write-verbose "Using default Graph version '$defaultVersion'"
             $defaultVersion
         }
-    } else {
-        $Version
     }
 
     $tenantQualifiedVersionSegment = if ( $graphType -eq ([GraphType]::AADGraph ) ) {

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -194,7 +194,7 @@ function Invoke-GraphRequest {
         }
     }
 
-    $apiVersion = if ( $Version -ne $null -or $version.length -ne 0 ) {
+    $apiVersion = if ( $Version -ne $null -and $version.length -ne 0 ) {
         write-verbose "Using version specified by caller: '$Version'"
         $Version
     } elseif ( $uriInfo -and $uriInfo.GraphVersion -and $uriInfo ) {

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -31,7 +31,12 @@ function New-GraphConnection {
         [GraphCloud] $Cloud = [GraphCloud]::Public,
 
         [parameter(parametersetname='custom')]
+        [parameter(parametersetname='msgraph')]
         [Guid] $AppId,
+
+        [parameter(parametersetname='custom')]
+        [parameter(parametersetname='msgraph')]
+        [Uri] $AppRedirectUri,
 
         [parameter(parametersetname='msgraph')]
         [parameter(parametersetname='custom')]
@@ -61,7 +66,7 @@ function New-GraphConnection {
             new-so GraphEndpoint ([GraphCloud]::Unknown) ([Graphtype]::MSGraph) $GraphEndpointUri $AuthenticationEndpointUri
         }
 
-        $app = new-so GraphApplication $AppId
+        $app = new-so GraphApplication $AppId $AppRedirectUri
         $identity = new-so GraphIdentity $app
         new-so GraphConnection $graphEndpoint $identity $ScopeNames
     }


### PR DESCRIPTION
### Description

Explicit support for v1 and v2 auth endpoints, make connection cmdlets like `Connect-Graph` and `Disconnect-Graph` deterministic, enable national clouds by choosing correct auth protocol for each cloud

### Implementation notes

Added an auth protocol enum to `GraphEndpoint` so that the correct auth protocol could be used by choosing the MSAL library for v2 and the ADAL library for v1. Also stopped trying to reuse part of the current context when creating new connections with `Connect-Graph`, made the reuse scenario modeled in an explicit and also constrained fashion via `-Reconnect` option on `Connect-Graph`.
 
- [x] All project tests pass successfully