### PR TITLE
Adamedx/apptoken

### DIFF
--- a/PoshGraph-SDK.psd1
+++ b/PoshGraph-SDK.psd1
@@ -136,6 +136,7 @@ AliasesToExport = @('gge', 'ggi')
         '.\src\common\GraphUtilities.ps1',
         '.\src\common\PreferenceHelper.ps1',
         '.\src\common\ProgressWriter.ps1',
+        '.\src\common\Secret.ps1',
         '.\src\graphservice\graphendpoint.ps1'
         '.\src\REST\GraphErrorRecorder.ps1',
         '.\src\REST\GraphRequest.ps1',

--- a/PoshGraph-SDK.psd1
+++ b/PoshGraph-SDK.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.2.0'
+ModuleVersion = '0.3.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -109,6 +109,9 @@ AliasesToExport = @('gge', 'ggi')
         '.\src\aliases.ps1',
         '.\src\cmdlets.ps1',
         '.\src\graph-sdk.ps1',
+        '.\src\auth\AuthProvider.ps1',
+        '.\src\auth\V1AuthProvider.ps1',
+        '.\src\auth\V2AuthProvider.ps1',
         '.\src\client\Application.ps1',
         '.\src\client\graphapplication.ps1',
         '.\src\client\GraphConnection.ps1',
@@ -164,34 +167,16 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# PoshGraph-SDK 0.2.0 Release Notes
+# PoshGraph-SDK 0.3.0 Release Notes
 
 ## New features
 
 ### Cmdlet features
 
-* ``Connect-Graph`` cmdlet: ``-Reconnect`` option to reconnect a previously disconnected Graph
-* ``Connect-Graph`` cmdlet: ``-ScopeNames`` supported with -Reconnect for permission elevation scenarios
-* ``Connect-Graph`` is now deterministic -- no longer based on context unless you specify ``-Reconnect``
-* ``Disconnect-Graph`` is now deterministic -- it removes cached tokens so that subsequent connection attempts behave as if it's the very first attempt
-* ``New-GraphConnection`` cmdlet: ``-AuthProtocol`` option configures authentication protocol to overridde defaults if needed
-* ``New-GraphConnection`` cmdlet: ``-RedirectUri`` option allows the use of custom applications with a particular redirect URI
-* ``New-GraphConnection`` cmdlet: ``-TenantName`` option allows the use of custom non-converged applications that require the tenant (including 'organizations') to be specified during authentication
-
 ### Library features
-
-* ``GraphIdentity`` now takes a ``TenantName`` argument to support v1 tenant-scoped applications
-* ``GraphIdentity`` exposes a ``GetUserInformation`` method to return data about the authenticated user (if any)
-* ``GraphEndpoint`` exposes a ``GetAuthUri`` method to return the URI for obtaining access tokens
 
 ## Fixed defects
 
-* ``Get-GraphItem``, ``Invoke-GraphRequest`` were ignoring ``-Version`` option -- these commands could only access the Graph ``v1.0`` API version
-* National cloud support through ``-Cloud`` arguments now works in commands like ``Connect-Graph``, ``New-GraphConnection``, etc.
-* Fix ignored scopes when ``-ScopeNames`` was specified with ``Connect-Graph``
-* Fix over-specification of parameters for ``New-GraphConnection`` due to missing default parameterset
-* Fix exception in ``Disconnect-Graph`` cmdlet due to call to removed method
-* 
 "@
 
     } # End of PSData hashtable

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,12 +2,17 @@
 
 ## To-do items -- prioritized
 
-* Add app creation
-* Add app enumeration
-* Add app updating
+* Customize README
+* Customize WALKTHROUGH
+
+* Add app-only mode -- symmetric
+* Add app-only mode -- asymmetric
 * Release
 
-* Add app-only mode
+* Add app enumeration
+* Add app creation
+* App deletion
+* Add app updating
 * Release
 
 * Clean up parse methods in GraphUtilities

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,9 +4,6 @@
 
 * Customize README
 * Customize WALKTHROUGH
-
-* Add app-only mode -- symmetric
-* Add app-only mode -- asymmetric
 * Release
 
 * Add app enumeration
@@ -84,7 +81,6 @@
 * Show-GraphRequest
 * Fix bug with graph update not clearing uri cache due to async
 * Enable schemaless execution
-* Auto-refresh token when expired
 * Use BEGIN, PROCESS, END in get-graphuri
 * Add basic help
 * Add uri completion
@@ -242,6 +238,8 @@
 * Add cert auth to v1 auth
 * Enable token cache for v1 auth
 * Fixed corruption / wrong auth protocol being used in connect-graph scenarios where shared static object was modified outside static methods
+* Add app-only mode -- symmetric
+* Add app-only mode -- asymmetric
 
 ### Postponed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,8 @@
 * Add app-only mode -- asymmetric
 * Release
 
+* Enable token cache for v1 auth
+
 * Add app enumeration
 * Add app creation
 * App deletion

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,11 @@
 
 ## To-do items -- prioritized
 
+* Add disconnect method to auth provider
+* Separate app and user auth methods in auth provider?
+* Remove special casing of v2 auth
+* Ensure disconnect occurs in reconnect scenarios
+
 * Customize README
 * Customize WALKTHROUGH
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,19 +2,12 @@
 
 ## To-do items -- prioritized
 
-* Add disconnect method to auth provider
-* Separate app and user auth methods in auth provider?
-* Remove special casing of v2 auth
-* Ensure disconnect occurs in reconnect scenarios
-
 * Customize README
 * Customize WALKTHROUGH
 
 * Add app-only mode -- symmetric
 * Add app-only mode -- asymmetric
 * Release
-
-* Enable token cache for v1 auth
 
 * Add app enumeration
 * Add app creation
@@ -244,6 +237,11 @@
 * Fix publishmoduletodev to use module publishing rather than nuget
 * Fix token refresh
 * Refactor into posh-graph core sdk and poshgraph ux
+* Add clear token method to auth provider
+* Remove special casing of v2 auth
+* Add cert auth to v1 auth
+* Enable token cache for v1 auth
+* Fixed corruption / wrong auth protocol being used in connect-graph scenarios where shared static object was modified outside static methods
 
 ### Postponed
 

--- a/src/auth/AuthProvider.ps1
+++ b/src/auth/AuthProvider.ps1
@@ -33,16 +33,16 @@ ScriptClass AuthProvider {
         $this.derivedProvider |=> GetUserInformation $token
     }
 
-    function AcquireInitialUserToken($authContext, $scopes) {
-        $this.derivedProvider |=> AcquireInitialUserToken $authContext $scopes
+    function AcquireFirstUserToken($authContext, $scopes) {
+        $this.derivedProvider |=> AcquireFirstUserToken $authContext $scopes
     }
 
-    function AcquireInitialAppToken($authContext, $scopes) {
-        $this.derivedProvider |=> AcquireInitialAppToken $authContext $scopes
+    function AcquireFirstAppToken($authContext) {
+        $this.derivedProvider |=> AcquireFirstAppToken $authContext
     }
 
-    function AcquireTokenFromToken($authContext, $scopes, $token) {
-        $this.derivedProvider |=> AcquireTokenFromToken $authContext $scopes $token
+    function AcquireRefreshedToken($authContext, $token) {
+        $this.derivedProvider |=> AcquireRefreshedToken $authContext $token
     }
 
     function ClearToken($authContext, $token) {

--- a/src/auth/AuthProvider.ps1
+++ b/src/auth/AuthProvider.ps1
@@ -1,0 +1,73 @@
+# Copyright 2018, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. (import-script ../graphservice/GraphEndpoint)
+
+ScriptClass AuthProvider {
+    $derivedProvider = $null
+
+    function __initialize($derivedProviderClass) {
+        $this.derivedProvider = new-so $derivedProviderClass.ClassName $this
+    }
+
+    function GetAuthContext($app, $graphEndpointUri, $authUri) {
+        [PSCustomObject]@{
+            App = $app
+            GraphEndpointUri = $graphEndpointUri
+            ProtocolContext = $this.derivedProvider |=> GetAuthContext $app $graphEndpointUri $authUri
+        }
+    }
+
+    function GetUserInformation($token) {
+        $this.serivedProvider |=> GetUserInformation $token
+    }
+
+    function AcquireInitialUserToken($authContext, $scopes) {
+        $this.derivedProvider |=> AcquireInitialUserToken $authContext $scopes
+    }
+
+    function AcquireInitialAppToken($authContext, $scopes) {
+        $this.derivedProvider |=> AcquireInitialAppToken $authContext $scopes
+    }
+
+    function AcquireTokenFromToken($authContext, $scopes, $token) {
+        $this.derivedProvider |=> AcquireTokenFromToken $authContext $scopes $token
+    }
+
+    static {
+        $providers = @{}
+
+        function InitializeProviders {
+            $this.providers.values | foreach {
+                $_ |=> InitializeProvider
+            }
+        }
+
+        function RegisterProvider([GraphAuthProtocol] $authProtocol, $provider) {
+            $this.providers.Add($authProtocol, $provider)
+        }
+
+        function GetProviderInstance([GraphAuthProtocol] $authProtocol) {
+            $protocol = if ( $authProtocol -ne ([GraphAuthProtocol]::Default) ) {
+                $authProtocol
+            } else {
+                [GraphAuthProtocol]::V2
+            }
+
+            $providerClass = $this.providers[$protocol]
+
+            new-so $this.ClassName $providerClass
+        }
+    }
+}

--- a/src/auth/AuthProvider.ps1
+++ b/src/auth/AuthProvider.ps1
@@ -45,6 +45,10 @@ ScriptClass AuthProvider {
         $this.derivedProvider |=> AcquireTokenFromToken $authContext $scopes $token
     }
 
+    function ClearToken($authContext, $token) {
+        $this.derivedProvider |=> ClearToken $authContext $token
+    }
+
     static {
         $providers = @{}
 

--- a/src/auth/AuthProvider.ps1
+++ b/src/auth/AuthProvider.ps1
@@ -30,7 +30,7 @@ ScriptClass AuthProvider {
     }
 
     function GetUserInformation($token) {
-        $this.serivedProvider |=> GetUserInformation $token
+        $this.derivedProvider |=> GetUserInformation $token
     }
 
     function AcquireInitialUserToken($authContext, $scopes) {

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -33,7 +33,7 @@ ScriptClass V1AuthProvider {
             $scopes = $null
         }
 
-        @{
+        [PSCustomObject]@{
             userId = $userId
             scopes = $scopes
         }
@@ -64,7 +64,7 @@ ScriptClass V1AuthProvider {
 
     function AcquireTokenFromToken($authContext, $scopes, $token) {
         write-verbose 'V1 auth provider acquiring token from existing token'
-        @{
+        [PSCustomObject]@{
             Status = 'NoOperation'
             Result = $token
             IsFaulted = $false

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -67,7 +67,7 @@ ScriptClass V1AuthProvider {
         # for user auth, app+user is the key -- if the auth context
         # has a token cache, that's all you need to look up the
         # previously used token
-        if ( $authContext.app |=> IsConfidential ) {
+        if ( $authContext.app.authtype -eq ([GraphAppAuthType]::AppOnly) ) {
             __AcquireAppToken $authContext $scopes
         } else {
             $userId = new-object Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier -ArgumentList $token.userinfo.uniqueid, ([Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifierType]::UniqueId)

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -39,7 +39,7 @@ ScriptClass V1AuthProvider {
         }
     }
 
-    function AcquireInitialUserToken($authContext, $scopes) {
+    function AcquireFirstUserToken($authContext, $scopes) {
         write-verbose 'V1 auth provider acquiring initial user token'
 
         $promptBehaviorValue = ([Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto)
@@ -52,13 +52,13 @@ ScriptClass V1AuthProvider {
             $promptBehavior)
     }
 
-    function AcquireInitialAppToken($authContext, $scopes) {
+    function AcquireFirstAppToken($authContext) {
         write-verbose 'V1 auth provider acquiring initial app token'
 
-        __AcquireAppToken $authContext $scopes
+        __AcquireAppToken $authContext
     }
 
-    function AcquireTokenFromToken($authContext, $scopes, $token) {
+    function AcquireRefreshedToken($authContext, $token) {
         write-verbose 'V1 auth provider refreshing existing token'
 
         # The token is irrelevant for v1 auth, since scopes are
@@ -68,7 +68,7 @@ ScriptClass V1AuthProvider {
         # has a token cache, that's all you need to look up the
         # previously used token
         if ( $authContext.app.authtype -eq ([GraphAppAuthType]::AppOnly) ) {
-            __AcquireAppToken $authContext $scopes
+            __AcquireAppToken $authContext
         } else {
             $userId = new-object Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier -ArgumentList $token.userinfo.uniqueid, ([Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifierType]::UniqueId)
             $authContext.protocolContext.AcquireTokenSilentAsync(
@@ -96,7 +96,7 @@ ScriptClass V1AuthProvider {
         }
     }
 
-    function __AcquireAppToken($authContext, $scopes) {
+    function __AcquireAppToken($authContext) {
         write-verbose 'V1 auth provider acquiring app token'
 
         if ( $authContext.app.secret.type -ne ([SecretType]::Password) ) {

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -28,8 +28,8 @@ ScriptClass V1AuthProvider {
         $userId = $null
         $scopes = $null
 
-        if ( $this.token ) {
-            $userId = $this.token.UserInfo.DisplayableId
+        if ( $token ) {
+            $userId = $token.UserInfo.DisplayableId
             $scopes = $null
         }
 

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -56,7 +56,7 @@ ScriptClass V1AuthProvider {
         write-verbose 'V1 auth provider acquiring initial app token'
 
         if ( $authContext.app.secret.type -ne ([SecretType]::Password) ) {
-            throw [ArgumentException]::new("Unsupported secret type '{0}' -- only 'Password' secrets are supported" -f $authContext.app.secret.type)
+            throw [ArgumentException]::new("Unsupported secret type '{0}' -- only 'Password' secrets are supported for the v1 auth protocol" -f $authContext.app.secret.type)
         }
 
         $clientSecret = new-object Microsoft.IdentityModel.Clients.ActiveDirectory.SecureClientSecret -ArgumentList $authcontext.app.secret.data
@@ -68,7 +68,7 @@ ScriptClass V1AuthProvider {
     }
 
     function AcquireTokenFromToken($authContext, $scopes, $token) {
-        write-verbose 'V1 auth provider acquiring token from existing token'
+        write-verbose 'V1 auth provider refreshing existing token'
         [PSCustomObject]@{
             Status = 'NoOperation'
             Result = $token

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -78,6 +78,24 @@ ScriptClass V1AuthProvider {
         }
     }
 
+    function ClearToken($authContext, $token) {
+        write-verbose 'V1 auth provider clearing existing token'
+        $userUpn = if ($token.userinfo) {
+            $token.userinfo.displayableid
+        }
+        write-verbose "Clearing token for user '$userUpn'"
+
+        $tokenAsCacheItem = $this.scriptclass.__tokencache.ReadItems() | where { $_.accesstoken -eq $token.accesstoken }
+
+        if ( $tokenAsCacheItem ) {
+            write-verbose "Found cached token, clearing..."
+            $this.scriptclass.__TokenCache.DeleteItem($tokenAsCacheItem)
+            write-verbose "Successfully cleared token from the cache"
+        } else {
+            write-verbose "Unable to find cached token, skipping unnecessary removal from cache"
+        }
+    }
+
     function __AcquireAppToken($authContext, $scopes) {
         write-verbose 'V1 auth provider acquiring app token'
 

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -1,0 +1,89 @@
+# Copyright 2018, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. (import-script AuthProvider)
+
+ScriptClass V1AuthProvider {
+    $base = $null
+    function __initialize( $base ) {
+        $this.base = $base
+    }
+
+    function GetAuthContext($app, $graphEndpointUri, $authUri) {
+        if ( $app |=> IsConfidential ) {
+            throw [NotImplementedExeception]::new("Confidential v1 auth not yet implemented")
+        } else {
+            New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authUri
+        }
+    }
+
+    function GetUserInformation($token) {
+        $userId = $null
+        $scopes = $null
+
+        if ( $this.token ) {
+            $userId = $this.token.UserInfo.DisplayableId
+            $scopes = $null
+        }
+
+        @{
+            userId = $userId
+            scopes = $scopes
+        }
+    }
+
+    function AcquireInitialUserToken($authContext, $scopes) {
+        write-verbose 'V1 auth provider acquiring initial user token'
+
+        $promptBehaviorValue = ([Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto)
+        $promptBehavior = new-object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehaviorValue
+
+        $authContext.protocolContext.AcquireTokenAsync(
+            $authContext.GraphEndpointUri,
+            $authContext.App.AppId,
+            $authContext.App.RedirectUri,
+            $promptBehavior)
+    }
+
+    function AcquireInitialAppToken($authContext, $scopes) {
+        write-verbose 'V1 auth provider acquiring initial app token'
+        [NotImplementedException]::new("V1 app authentication not yet implemented")
+    }
+
+    function AcquireTokenFromToken($authContext, $scopes, $token) {
+        write-verbose 'V1 auth provider acquiring token from existing token'
+        @{
+            Status = 'NoOperation'
+            Result = $token
+            IsFaulted = $false
+        }
+    }
+
+    static {
+        $__AuthLibraryLoaded = $false
+        $__UserTokenCache = $null
+        $__AppTokenCache = $null
+
+        function InitializeProvider {
+            if ( ! $this.__AuthLibraryLoaded ) {
+                import-assembly ../../lib/Microsoft.IdentityModel.Clients.ActiveDirectory.dll
+                $this.__AuthLibraryLoaded = $true
+            }
+        }
+
+        function RegisterProvider {
+            $::.AuthProvider |=> RegisterProvider ([GraphAuthProtocol]::v1) $this
+        }
+    }
+}

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -55,7 +55,12 @@ ScriptClass V1AuthProvider {
     function AcquireInitialAppToken($authContext, $scopes) {
         write-verbose 'V1 auth provider acquiring initial app token'
 
-        $clientCredential = new-object Microsoft.IdentityModel.Clients.ActiveDirectory.ClientCredential -ArgumentList $authContext.App.AppId, $authContext.App.Secret
+        if ( $authContext.app.secret.type -ne ([SecretType]::Password) ) {
+            throw [ArgumentException]::new("Unsupported secret type '{0}' -- only 'Password' secrets are supported" -f $authContext.app.secret.type)
+        }
+
+        $clientSecret = new-object Microsoft.IdentityModel.Clients.ActiveDirectory.SecureClientSecret -ArgumentList $authcontext.app.secret.data
+        $clientCredential = new-object Microsoft.IdentityModel.Clients.ActiveDirectory.ClientCredential -ArgumentList $authContext.App.AppId, $clientSecret
 
         $authContext.protocolContext.AcquireTokenAsync(
             $authContext.GraphEndpointUri,

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -21,11 +21,7 @@ ScriptClass V1AuthProvider {
     }
 
     function GetAuthContext($app, $graphEndpointUri, $authUri) {
-        if ( $app |=> IsConfidential ) {
-            throw [NotImplementedExeception]::new("Confidential v1 auth not yet implemented")
-        } else {
-            New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authUri
-        }
+        New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authUri
     }
 
     function GetUserInformation($token) {
@@ -58,7 +54,12 @@ ScriptClass V1AuthProvider {
 
     function AcquireInitialAppToken($authContext, $scopes) {
         write-verbose 'V1 auth provider acquiring initial app token'
-        [NotImplementedException]::new("V1 app authentication not yet implemented")
+
+        $clientCredential = new-object Microsoft.IdentityModel.Clients.ActiveDirectory.ClientCredential -ArgumentList $authContext.App.AppId, $authContext.App.Secret
+
+        $authContext.protocolContext.AcquireTokenAsync(
+            $authContext.GraphEndpointUri,
+            $clientCredential)
     }
 
     function AcquireTokenFromToken($authContext, $scopes, $token) {

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -22,8 +22,8 @@ ScriptClass V2AuthProvider {
 
     function GetAuthContext($app, $graphUri, $authUri) {
         if ( $app |=> IsConfidential ) {
-            $base64Secret = $app.secret # __SecretStringToBase64EncodedString $app.secret
-            $credential = New-Object "Microsoft.Identity.Client.ClientCredential" -ArgumentList $base64Secret
+
+            $credential = New-Object Microsoft.Identity.Client.ClientCredential -ArgumentList ($app.secret |=> GetSecretData)
 
             New-Object "Microsoft.Identity.Client.ConfidentialClientApplication" -ArgumentList @(
                 $App.AppId,

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -41,9 +41,9 @@ ScriptClass V2AuthProvider {
         $userId = $null
         $scopes = $null
 
-        if ( $this.token ) {
-            $userId = $this.token.User.DisplayableId
-            $scopes = $this.token.scopes
+        if ( $token ) {
+            $userId = $token.User.DisplayableId
+            $scopes = $token.scopes
         }
 
         [PSCustomObject]@{

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -46,7 +46,7 @@ ScriptClass V2AuthProvider {
             $scopes = $this.token.scopes
         }
 
-        @{
+        [PSCustomObject]@{
             userId = $userId
             scopes = $scopes
         }
@@ -64,14 +64,14 @@ ScriptClass V2AuthProvider {
     function AcquireInitialAppToken($authContext, $scopes) {
         write-verbose 'V2 auth provider acquiring initial app token'
         $requestedScopes = new-object System.Collections.Generic.List[string]
-        $defaultScope = $authContext.GraphEndpointUri.tostring().trimend(), '.default' -join '/'
+        $defaultScope = $authContext.GraphEndpointUri.tostring().trimend('/'), '.default' -join '/'
         $requestedScopes.Add($defaultScope)
 
         $authContext.protocolContext.AcquireTokenForClientAsync($requestedScopes)
     }
 
     function AcquireTokenFromToken($authContext, $scopes, $token) {
-        write-verbose 'V2 auth provider acquiring token from existing token'
+        write-verbose 'V2 auth provider refreshing existing token'
         if ( $authContext.app |=> IsConfidential ) {
             $requestedScopes = new-object System.Collections.Generic.List[string]
             $defaultScope = $authContext.GraphEndpointUri.tostring().trimend(), '.default' -join '/'

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -1,0 +1,98 @@
+# Copyright 2018, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. (import-script AuthProvider)
+
+ScriptClass V2AuthProvider {
+    $base = $null
+    function __initialize( $base ) {
+        $this.base = $base
+    }
+
+    function GetAuthContext($app, $graphUri, $authUri) {
+        if ( $app |=> IsConfidential ) {
+            $base64Secret = $app.secret # __SecretStringToBase64EncodedString $app.secret
+            $credential = New-Object "Microsoft.Identity.Client.ClientCredential" -ArgumentList $base64Secret
+
+            New-Object "Microsoft.Identity.Client.ConfidentialClientApplication" -ArgumentList @(
+                $App.AppId,
+                $authUri,
+                $app.RedirectUri,
+                $credential,
+                $null,
+                $null)
+        } else {
+            New-Object "Microsoft.Identity.Client.PublicClientApplication" -ArgumentList $App.AppId, $authUri, $this.scriptclass.__UserTokenCache
+        }
+    }
+
+    function GetUserInformation($token) {
+        $userId = $null
+        $scopes = $null
+
+        if ( $this.token ) {
+            $userId = $this.token.User.DisplayableId
+            $scopes = $this.token.scopes
+        }
+
+        @{
+            userId = $userId
+            scopes = $scopes
+        }
+    }
+
+    function AcquireInitialUserToken($authContext, $scopes) {
+        write-verbose 'V2 auth provider acquiring initial user token'
+        if ( $scopes -eq $null -or $scopes.length -eq 0 ) {
+            throw [ArgumentException]::new('No scopes specified for v1 auth protocol, at least one scope is required')
+        }
+
+        $authContext.protocolContext.AcquireTokenAsync($scopes)
+    }
+
+    function AcquireInitialAppToken($authContext, $scopes) {
+        if ( $scopes -eq $null -or $scopes.length -eq 0 ) {
+            throw [ArgumentException]::new('No scopes specified for v1 auth protocol, at least one scope is required')
+        }
+
+        write-verbose 'V2 auth provider acquiring initial app token'
+        $authContext.protocolContext.AcquireTokenForClientAsync($scopes)
+    }
+
+    function AcquireTokenFromToken($authContext, $scopes, $token) {
+        write-verbose 'V2 auth provider acquiring token from existing token'
+        $authContext.protocolContext.AcquireTokenSilentAsync($scopes, $token.user)
+    }
+
+    static {
+        $__AuthLibraryLoaded = $false
+        $__UserTokenCache = $null
+        $__AppTokenCache = $null
+
+        function InitializeProvider {
+            if ( ! $this.__AuthLibraryLoaded ) {
+                import-assembly ../../lib/Microsoft.Identity.Client.dll
+                $this.__AuthLibraryLoaded = $true
+            }
+
+            if ( ! $this.__UserTokenCache ) {
+                $this.__UserTokenCache = New-Object Microsoft.Identity.Client.TokenCache
+            }
+        }
+
+        function RegisterProvider {
+            $::.AuthProvider |=> RegisterProvider ([GraphAuthProtocol]::v2) $this
+        }
+    }
+}

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -97,7 +97,7 @@ ScriptClass V2AuthProvider {
                 $this.__UserTokenCache = New-Object Microsoft.Identity.Client.TokenCache
             }
 
-            if ( ! $this._AppTokenCache ) {
+            if ( ! $this.__AppTokenCache ) {
                 $this.__AppTokenCache = New-Object Microsoft.Identity.Client.TokenCache
             }
         }

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -21,7 +21,7 @@ ScriptClass V2AuthProvider {
     }
 
     function GetAuthContext($app, $graphUri, $authUri) {
-        if ( $app |=> IsConfidential ) {
+        if ( $app.authtype -eq ([GraphAppAuthType]::AppOnly) ) {
 
             $credential = New-Object Microsoft.Identity.Client.ClientCredential -ArgumentList ($app.secret |=> GetSecretData)
 
@@ -72,7 +72,7 @@ ScriptClass V2AuthProvider {
 
     function AcquireTokenFromToken($authContext, $scopes, $token) {
         write-verbose 'V2 auth provider refreshing existing token'
-        if ( $authContext.app |=> IsConfidential ) {
+        if ( $authContext.app.authtype -eq ([GraphAppAuthType]::AppOnly) ) {
             $requestedScopes = new-object System.Collections.Generic.List[string]
             $defaultScope = $authContext.GraphEndpointUri.tostring().trimend(), '.default' -join '/'
             $requestedScopes.Add($defaultScope)

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -82,6 +82,14 @@ ScriptClass V2AuthProvider {
         }
     }
 
+    function ClearToken($authContext, $token) {
+        write-verbose 'V2 auth provider clearing existing token'
+        $user = $token.user
+        $userUpn = $user.displayableid
+        write-verbose "Clearing token for user '$userUpn'"
+        $authContext.protocolContext.Remove($user)
+    }
+
     static {
         $__AuthLibraryLoaded = $false
         $__UserTokenCache = $null

--- a/src/client/GraphApplication.ps1
+++ b/src/client/GraphApplication.ps1
@@ -38,9 +38,6 @@ ScriptClass GraphApplication {
         }
 
         if ( $secret ) {
-            if ( ! $appId -or -! $RedirectUri ) {
-                throw [ArgumentException]::new("A secret was specified, but both an AppId and RedirectUri MUST be specified")
-            }
             $this.secret = new-so Secret $secret
             $this.AuthType = ([GraphAppAuthType]::AppOnly)
         }

--- a/src/client/GraphApplication.ps1
+++ b/src/client/GraphApplication.ps1
@@ -25,7 +25,7 @@ ScriptClass GraphApplication {
     $AuthType = ([GraphAppAuthType]::Delegated)
     $RedirectUri = $null
 
-    function __initialize($appId = $null, $RedirectUri = $null) {
+    function __initialize($appId = $null, $RedirectUri = $null, $secret = $null) {
         $this.AppId = if ( $appId -ne $null ) {
             $appId
         } else {
@@ -34,6 +34,14 @@ ScriptClass GraphApplication {
             }
 
             $::.Application.AppId
+        }
+
+        if ( $secret ) {
+            if ( ! $appId -or -! $RedirectUri ) {
+                throw [ArgumentException]::new("A secret was specified, but both an AppId and RedirectUri MUST be specified")
+            }
+            $this.secret = $secret
+            $this.AuthType = ([GraphAppAuthType]::AppOnly)
         }
 
         $this.RedirectUri = if ( $RedirectUri ) {
@@ -45,5 +53,9 @@ ScriptClass GraphApplication {
 
     function __GetDefaultRedirectUri($appId) {
         'msal{0}://auth' -f $appId
+    }
+
+    function IsConfidential {
+        $this.Secret -ne $null
     }
 }

--- a/src/client/GraphApplication.ps1
+++ b/src/client/GraphApplication.ps1
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 . (import-script Application)
+. (import-script ../common/Secret)
 
 enum GraphAppAuthType {
     Delegated
@@ -40,7 +41,7 @@ ScriptClass GraphApplication {
             if ( ! $appId -or -! $RedirectUri ) {
                 throw [ArgumentException]::new("A secret was specified, but both an AppId and RedirectUri MUST be specified")
             }
-            $this.secret = $secret
+            $this.secret = new-so Secret $secret
             $this.AuthType = ([GraphAppAuthType]::AppOnly)
         }
 

--- a/src/client/GraphConnection.ps1
+++ b/src/client/GraphConnection.ps1
@@ -92,8 +92,8 @@ ScriptClass GraphConnection {
     }
 
     static {
-        function NewSimpleConnection([GraphType] $graphType, [GraphCloud] $cloud = 'Public', [String[]] $ScopeNames, $anonymous = $false, $tenantName = $null) {
-            $endpoint = new-so GraphEndpoint $cloud $graphType
+        function NewSimpleConnection([GraphType] $graphType, [GraphCloud] $cloud = 'Public', [String[]] $ScopeNames, $anonymous = $false, $tenantName = $null, $authProtocol = $null ) {
+            $endpoint = new-so GraphEndpoint $cloud $graphType $null $null $authProtocol
             $app = new-so GraphApplication
             $identity = if ( ! $anonymous ) {
                 new-so GraphIdentity $app $endpoint $tenantName

--- a/src/client/GraphConnection.ps1
+++ b/src/client/GraphConnection.ps1
@@ -44,7 +44,7 @@ ScriptClass GraphConnection {
     function Connect {
         if ( ($this.Status -eq [GraphConnectionStatus]::Online) -and (! $this.connected) ) {
             if ($this.Identity) {
-                $this.Identity |=> Authenticate $this.GraphEndpoint $this.Scopes
+                $this.Identity |=> Authenticate $this.Scopes
             }
             $this.connected = $true
         }
@@ -58,7 +58,7 @@ ScriptClass GraphConnection {
         if ( $this.Status -eq [GraphConnectionStatus]::Online ) {
             if ( $this.GraphEndpoint.Type -eq [GraphType]::MSGraph ) {
                 # Trust the library's token cache to get a new token if necessary
-                $this.Identity |=> Authenticate $this.GraphEndpoint $this.Scopes $true
+                $this.Identity |=> Authenticate $this.Scopes $true
                 $this.connected = $true
             } else {
                 Connect

--- a/src/client/GraphContext.ps1
+++ b/src/client/GraphContext.ps1
@@ -31,7 +31,7 @@ ScriptClass GraphContext {
 
         $graphVersion = if ( $apiVersion ) { $apiVersion } else { $this.scriptclass |=> GetDefaultVersion }
 
-        $this.connection = $this.scriptclass |=> GetConnection
+        $this.connection = if ( $connection ) { $connection } else { $this.scriptclass |=> GetConnection }
         $this.version = $graphVersion
         $this.name = $name
         $this.location = $this.scriptclass |=> GetDefaultLocation

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -14,6 +14,9 @@
 
 . (import-script ../GraphService/GraphEndpoint)
 . (import-script GraphApplication)
+. (import-script ../auth/AuthProvider)
+. (import-script ../auth/V1AuthProvider)
+. (import-script ../auth/V2AuthProvider)
 
 ScriptClass GraphIdentity {
     $App = strict-val [PSCustomObject]
@@ -23,14 +26,10 @@ ScriptClass GraphIdentity {
     $TenantName = $null
 
     static {
-        $__AuthLibraryLoaded = $null
-        $__TokenCache = $null
-
-        function __InitializeTokenCache {
-            if ( ! $this.__TokenCache ) {
-                # Initialize this cache once per process
-                $this.__TokenCache = New-Object "Microsoft.Identity.Client.TokenCache"
-            }
+        function __initialize {
+            $::.V1AuthProvider |=> RegisterProvider
+            $::.V2AuthProvider |=> RegisterProvider
+            $::.AuthProvider |=> InitializeProviders
         }
     }
 
@@ -41,57 +40,20 @@ ScriptClass GraphIdentity {
     }
 
     function GetUserInformation {
-        $authProtocol = $this.GraphEndPoint.AuthProtocol
+        $providerInstance = $::.AuthProvider |=> GetProviderInstance $graphEndpoint.AuthProtocol
 
-        $userId = $null
-        $scopes = $null
-
-        if ( $this.token ) {
-            if ( $authProtocol -eq ([GraphAuthProtocol]::v1) ) {
-                $userId = $this.token.UserInfo.DisplayableId
-                $scopes = $null
-            } elseif ( $authProtocol -eq ([GraphAuthProtocol]::v2) ) {
-                $userId = $this.token.User.DisplayableId
-                $scopes = $this.token.scopes
-            } else {
-                throw ("Unknown auth protocol '{0}'" -f $authProtocol)
-            }
-        }
-
-        @{
-            userId = $userId
-            scopes = $scopes
-        }
+        $providerInstace |=> GetUserInformation $token
     }
 
     function Authenticate($graphEndpoint, $scopes = $null) {
         if ( $this.token ) {
             $tokenTimeLeft = $this.token.expireson - [DateTime]::UtcNow
             write-verbose ("Found existing token with {0} minutes left before expiration" -f $tokenTimeLeft.TotalMinutes)
-
-            if ( $graphEndpoint.AuthProtocol -ne [GraphAuthProtocol]::v2 ) {
-                write-verbose "Using existing token -- will not attempt refresh since it is not a v2 token"
-                return
-            }
         }
-
-        if ( $graphEndpoint.AuthProtocol -ne [GraphAuthProtocol]::v1 -and ( $scopes -eq $null -or $scopes.length -eq 0 ) ) {
-            throw [ArgumentException]::new('No scopes specified for v1 auth protocol, at least one scope is required')
-        }
-
-        $this.scriptclass |=> __LoadAuthLibrary $graphEndpoint.AuthProtocol
 
         write-verbose ("Getting token for resource {0} from auth endpoint: {1} with protocol {2}" -f $graphEndpoint.Graph, $graphEndpoint.Authentication, $graphEndpoint.AuthProtocol)
 
-        # Cast it in case this is a deserialized object --
-        # workaround for a defect in ScriptClass
-        $this.Token = switch ([GraphAuthProtocol] $graphEndpoint.AuthProtocol) {
-            ([GraphAuthProtocol]::v2) { getV2ProtocolGraphToken $graphEndpoint $scopes }
-            ([GraphAuthProtocol]::v1) { getV1ProtocolGraphToken $graphEndpoint $scopes }
-            default {
-                throw "Unexpected Graph protocol '$($graphEndpoint.GraphAuthProtocol)'"
-            }
-        }
+        $this.Token = getGraphToken $graphEndpoint $scopes
 
         if ($this.token -eq $null) {
             throw "Failed to acquire token, no additional error information"
@@ -116,64 +78,34 @@ ScriptClass GraphIdentity {
         $this.token = $null
     }
 
-    static {
-        function __LoadAuthLibrary([GraphAuthProtocol] $authProtocol) {
-            if ( $this.__AuthLibraryLoaded -eq $null ) {
-                $this.__AuthLibraryLoaded = @{}
-            }
-
-            if ( ! $this.__AuthLibraryLoaded[$authProtocol] ) {
-                # Cast it in case this is a deserialized object --
-                # workaround for a defect in ScriptClass
-                switch ( [GraphAuthProtocol] $authProtocol ) {
-                    ([GraphAuthProtocol]::v2) {
-                        import-assembly ../../lib/Microsoft.Identity.Client.dll
-                    }
-                    ([GraphAuthProtocol]::v1) {
-                        import-assembly ../../lib/Microsoft.IdentityModel.Clients.ActiveDirectory.dll
-                    }
-                    default {
-                        throw "Unexpected graph type '$authProtocol'"
-                    }
-                }
-
-                $this.__AuthLibraryLoaded[$authProtocol] = $true
-            } else {
-                write-verbose "Library already loaded for graph type '$authProtocol'"
-            }
-        }
-    }
-
-    function getV2ProtocolGraphToken($graphEndpoint, $scopes) {
+    function getGraphToken($graphEndpoint, $scopes) {
+        write-verbose "Using generic path..."
         write-verbose "Attempting to get token for '$($graphEndpoint.Graph)' using V2 protocol..."
         write-verbose "Using app id '$($this.App.AppId)'"
 
-        $this.scriptclass |=> __InitializeTokenCache
-        $authUri = $graphEndpoint |=> GetAuthUri $this.TenantName
-        write-verbose ("Sending auth request to auth uri '{0}'" -f $authUri)
-
-        $msalAuthContext = New-Object "Microsoft.Identity.Client.PublicClientApplication" -ArgumentList $this.App.AppId, $authUri, $this.scriptclass.__TokenCache
-
-        $requestedScopes = new-object System.Collections.Generic.List[string]
-
         write-verbose ("Adding scopes to request: {0}" -f ($scopes -join ';'))
-
+        $requestedScopes = new-object System.Collections.Generic.List[string]
         $scopes | foreach {
             $requestedScopes.Add($_)
         }
 
+        $authUri = $graphEndpoint |=> GetAuthUri $this.TenantName
+        write-verbose ("Sending auth request to auth uri '{0}'" -f $authUri)
+
+        $providerInstance = $::.AuthProvider |=> GetProviderInstance $graphEndpoint.AuthProtocol
+
+        $authContext = $providerInstance |=> GetAuthContext $this.app $graphEndpoint.Graph $authUri
+
         $authResult = if ( $this.token ) {
-            # Use the silent API since we already have a token that includes a
-            # refresh token -- even if our access token has expired, the refresh
-            # token can be used to get a new access token without a prompt for ux
-            write-verbose 'Acquiring token from existing token -- no user interaction'
-            $msalAuthContext.AcquireTokenSilentAsync($requestedScopes, $this.token.User)
+            $providerInstance |=> AcquireTokenFromToken $authContext $requestedScopes $this.token
         } else {
-            # We have no token, so we cannot use the silent flow and a ux
-            # prompt must be shown
-            write-verbose 'Acquiring new token -- user interaction will be required'
-            $msalAuthContext.AcquireTokenAsync($requestedScopes)
+            if ( $this.app |=> IsConfidential ) {
+                $providerInstance |=> AcquireInitialAppToken $authContext $requestedScopes
+            } else {
+                $providerInstance |=> AcquireInitialUserToken $authContext $requestedScopes
+            }
         }
+
         write-verbose ("`nToken request status: {0}" -f $authResult.Status)
 
         if ( $authResult.Status -eq 'Faulted' ) {
@@ -187,34 +119,12 @@ ScriptClass GraphIdentity {
             throw $authResult.Exception
         }
 
-        $this.V2AuthContext = $msalAuthContext
-        $result
-    }
-
-    function getV1ProtocolGraphToken($graphEndpoint, $scopes) {
-        write-verbose "Attempting to get token for '$($graphEndpoint.Graph)' using V1 protocol..."
-        write-verbose "Using app id '$($this.App.AppId)'"
-        write-verbose "Using redirect uri '$($this.app.redirecturi)'"
-
-        $authUri = $graphEndpoint |=> GetAuthUri $this.TenantName
-        write-verbose ("Sending auth request to auth uri '{0}'" -f $authUri)
-
-        $adalAuthContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" -ArgumentList $authUri
-
-        $promptBehaviorValue = ([Microsoft.IdentityModel.Clients.ActiveDirectory.PromptBehavior]::Auto)
-
-        $promptBehavior = new-object "Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformParameters" -ArgumentList $promptBehaviorValue
-
-        $authResult = $adalAuthContext.AcquireTokenAsync(
-            $graphEndpoint.Graph,
-            $this.App.AppId,
-            $this.App.RedirectUri,
-            $promptBehavior)
-
-        if ( $authResult.Status -eq 'Faulted' ) {
-            throw "Failed to acquire token for uri '$($graphEndpoint.Graph)' for AppID '$($this.App.AppId)'`n" + $authResult.exception, $authResult.exception
+        $this.V2AuthContext = if ( $graphendpoint.authprotocol -eq ([GraphAuthProtocol]::v2) ) {
+            $authContext.protocolContext
         }
-        $authResult.Result
+
+        $result
     }
 }
 
+$::.GraphIdentity |=> __initialize

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -38,6 +38,8 @@ ScriptClass GraphIdentity {
         $this.App = $app
         $this.GraphEndpoint = $graphEndpoint
         $this.TenantName = $tenantName
+
+        __UpdateTenantDisplayInfo
     }
 
     function GetUserInformation {
@@ -131,7 +133,9 @@ ScriptClass GraphIdentity {
 
     function __UpdateTenantDisplayInfo {
         $tenant = try {
-            (([uri] $this.token.authority).segments | select -last 1).trimend('/')
+            if ( $this.token ) {
+                (([uri] $this.token.authority).segments | select -last 1).trimend('/')
+            }
         } catch {
         }
 
@@ -144,7 +148,9 @@ ScriptClass GraphIdentity {
 
         $tenantName = $null
         $tenantId = try {
-            $this.token.tenantId
+            if ( $this.token ) {
+                $this.token.tenantId
+            }
         } catch {
         }
 
@@ -154,6 +160,10 @@ ScriptClass GraphIdentity {
             }
         } catch {
             $tenantName = $tenant
+        }
+
+        if ( ! $tenantName ) {
+            $tenantName = $this.tenantName
         }
 
         if ( ! $tenantId ) {

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -41,7 +41,6 @@ ScriptClass GraphIdentity {
 
     function GetUserInformation {
         $providerInstance = $::.AuthProvider |=> GetProviderInstance $graphEndpoint.AuthProtocol
-
         $providerInstace |=> GetUserInformation $token
     }
 
@@ -63,9 +62,13 @@ ScriptClass GraphIdentity {
     function ClearAuthentication {
         if ( $this.token ) {
             $userUpn = if ( $this.V2AuthContext ) {
-                $this.token.user.displayableid
+                if ( $this.token.user ) {
+                    $this.token.user.displayableid
+                }
             } else {
-                $this.token.userinfo.displayableid
+                if ( $this.token.userinfo ) {
+                    $this.token.userinfo.displayableid
+                }
             }
             write-verbose "Clearing token for user '$userUpn'"
             if ( $this.V2AuthContext ) {

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -41,8 +41,8 @@ ScriptClass GraphIdentity {
 
     function GetUserInformation {
         if ( $this.App.AuthType -eq ([GraphAppAuthType]::Delegated) ) {
-                 $providerInstance = $::.AuthProvider |=> GetProviderInstance $graphEndpoint.AuthProtocol
-                 $providerInstace |=> GetUserInformation $token
+                 $providerInstance = $::.AuthProvider |=> GetProviderInstance $this.graphEndpoint.AuthProtocol
+                 $providerInstance |=> GetUserInformation $this.token
         } else {
             [PSCustomObject]@{
                 AppId = $this.App.AppId

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -53,15 +53,15 @@ ScriptClass GraphIdentity {
         }
     }
 
-    function Authenticate($graphEndpoint, $scopes = $null) {
+    function Authenticate($scopes = $null) {
         if ( $this.token ) {
             $tokenTimeLeft = $this.token.expireson - [DateTime]::UtcNow
             write-verbose ("Found existing token with {0} minutes left before expiration" -f $tokenTimeLeft.TotalMinutes)
         }
 
-        write-verbose ("Getting token for resource {0} from auth endpoint: {1} with protocol {2}" -f $graphEndpoint.Graph, $graphEndpoint.Authentication, $graphEndpoint.AuthProtocol)
+        write-verbose ("Getting token for resource {0} from auth endpoint: {1} with protocol {2}" -f $this.graphEndpoint.Graph, $this.graphEndpoint.Authentication, $this.graphEndpoint.AuthProtocol)
 
-        $this.Token = getGraphToken $graphEndpoint $scopes
+        $this.Token = getGraphToken $this.graphEndpoint $scopes
 
         if ($this.token -eq $null) {
             throw "Failed to acquire token, no additional error information"

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -88,10 +88,6 @@ ScriptClass GraphIdentity {
         write-verbose "Using app id '$($this.App.AppId)'"
 
         write-verbose ("Adding scopes to request: {0}" -f ($scopes -join ';'))
-        $requestedScopes = new-object System.Collections.Generic.List[string]
-        $scopes | foreach {
-            $requestedScopes.Add($_)
-        }
 
         $authUri = $graphEndpoint |=> GetAuthUri $this.TenantName
         write-verbose ("Sending auth request to auth uri '{0}'" -f $authUri)
@@ -101,12 +97,12 @@ ScriptClass GraphIdentity {
         $authContext = $providerInstance |=> GetAuthContext $this.app $graphEndpoint.Graph $authUri
 
         $authResult = if ( $this.token ) {
-            $providerInstance |=> AcquireTokenFromToken $authContext $requestedScopes $this.token
+            $providerInstance |=> AcquireRefreshedToken $authContext $this.token
         } else {
             if ( $this.App.AuthType -eq ([GraphAppAuthType]::Apponly) ) {
-                $providerInstance |=> AcquireInitialAppToken $authContext $requestedScopes
+                $providerInstance |=> AcquireFirstAppToken $authContext
             } else {
-                $providerInstance |=> AcquireInitialUserToken $authContext $requestedScopes
+                $providerInstance |=> AcquireFirstUserToken $authContext $scopes
             }
         }
 

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -103,7 +103,7 @@ ScriptClass GraphIdentity {
         $authResult = if ( $this.token ) {
             $providerInstance |=> AcquireTokenFromToken $authContext $requestedScopes $this.token
         } else {
-            if ( $this.app |=> IsConfidential ) {
+            if ( $this.App.AuthType -eq ([GraphAppAuthType]::Apponly) ) {
                 $providerInstance |=> AcquireInitialAppToken $authContext $requestedScopes
             } else {
                 $providerInstance |=> AcquireInitialUserToken $authContext $requestedScopes

--- a/src/cmdlets/Connect-Graph.ps1
+++ b/src/cmdlets/Connect-Graph.ps1
@@ -63,7 +63,6 @@ function Connect-Graph {
         $newContext = $::.LogicalGraphManager |=> Get |=> NewContext $context $Connection
 
         $::.GraphContext |=> SetCurrentByName $newContext.name
-        $newContext |=> UpdateConnection $connection
     } else {
         write-verbose "Connecting context '$($context.name)'"
         $applicationId = if ( $AppId ) {

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -80,7 +80,7 @@ function New-GraphConnection {
         [parameter(parametersetname='cert')]
         [parameter(parametersetname='certpath')]
         [parameter(parametersetname='customendpoint')]
-        [GraphAuthProtocol] $GraphAuthProtocol = [GraphAuthProtocol]::Default,
+        [GraphAuthProtocol] $AuthProtocol = [GraphAuthProtocol]::Default,
 
         [String] $TenantName = $null
     )
@@ -97,8 +97,8 @@ function New-GraphConnection {
         ([GraphType]::MSGraph)
     }
 
-    $specifiedAuthProtocol = if ( $GraphAuthProtocol -ne ([GraphAuthProtocol]::Default) ) {
-        $GraphAuthProtocol
+    $specifiedAuthProtocol = if ( $AuthProtocol -ne ([GraphAuthProtocol]::Default) ) {
+        $AuthProtocol
     }
 
     $specifiedScopes = if ( $ScopeNames ) {
@@ -110,7 +110,7 @@ function New-GraphConnection {
         @('User.Read')
     }
 
-    $computedAuthProtocol = $::.GraphEndpoint |=> GetAuthProtocol $GraphAuthProtocol $validatedCloud $GraphType
+    $computedAuthProtocol = $::.GraphEndpoint |=> GetAuthProtocol $AuthProtocol $validatedCloud $GraphType
 
     if ( $GraphEndpointUri -eq $null -and $AuthenticationEndpointUri -eq $null -and $specifiedAuthProtocol -and $appId -eq $null ) {
         write-verbose 'Simple connection specified with no custom uri, auth protocol, or app id'

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -40,7 +40,7 @@ function New-GraphConnection {
         [parameter(parametersetname='customcertname', mandatory=$true)]
         [parameter(parametersetname='customcert', mandatory=$true)]
         [parameter(parametersetname='customendpoint', mandatory=$true)]
-        [Guid] $AppId,
+        $AppId = $null,
 
         [parameter(parametersetname='msgraph')]
         [parameter(parametersetname='custom')]
@@ -114,11 +114,11 @@ function New-GraphConnection {
         $GraphAuthProtocol
     }
 
-    if ( $GraphEndpointUri -eq $null -and $AuthenticationEndpointUri -eq $null -and $specifiedAuthProtocol) {
-        $::.GraphConnection |=> NewSimpleConnection $graphType $validatedCloud $ScopeNames
-    } else {
-        $computedAuthProtocol = $::.GraphEndpoint |=> GetAuthProtocol $GraphAuthProtocol $validatedCloud $GraphType
+    $computedAuthProtocol = $::.GraphEndpoint |=> GetAuthProtocol $GraphAuthProtocol $validatedCloud $GraphType
 
+    if ( $GraphEndpointUri -eq $null -and $AuthenticationEndpointUri -eq $null -and $specifiedAuthProtocol -and $appId -eq $null ) {
+        $::.GraphConnection |=> NewSimpleConnection $graphType $validatedCloud $ScopeNames $false $tenantName $computedAuthProtocol
+    } else {
         $graphEndpoint = if ( $GraphEndpointUri -eq $null ) {
             new-so GraphEndpoint $validatedCloud $graphType $null $null $computedAuthProtocol
         } else {

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -89,10 +89,6 @@ function New-GraphConnection {
         [String] $TenantName = $null
     )
 
-    if ( $AppCertificate ) {
-        throw [NotImplementedException]::new("The -AppCertificate option is not yet implemented")
-    }
-
     if ( $AppCertificatePath ) {
         throw [NotImplementedException]::new("The -AppCertificatePath option is not yet implemented")
     }

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -37,6 +37,8 @@ function New-GraphConnection {
         [parameter(parametersetname='msgraph')]
         [parameter(parametersetname='custom', mandatory=$true)]
         [parameter(parametersetname='customsecret', mandatory=$true)]
+        [parameter(parametersetname='customcertname', mandatory=$true)]
+        [parameter(parametersetname='customcert', mandatory=$true)]
         [parameter(parametersetname='customendpoint', mandatory=$true)]
         [Guid] $AppId,
 
@@ -50,7 +52,20 @@ function New-GraphConnection {
         [parameter(parametersetname='custom')]
         [parameter(parametersetname='customsecret', mandatory=$true)]
         [parameter(parametersetname='customendpoint')]
-        [Guid] $AppIdSecret,
+#        [SecureString] $AppSecret = $null,
+        [String] $AppSecret = $null,
+
+        [parameter(parametersetname='msgraph')]
+        [parameter(parametersetname='custom')]
+        [parameter(parametersetname='customcertname', mandatory=$true)]
+        [parameter(parametersetname='customendpoint')]
+        [string] $AppCertificatePath = $null,
+
+        [parameter(parametersetname='msgraph')]
+        [parameter(parametersetname='custom')]
+        [parameter(parametersetname='customcert', mandatory=$true)]
+        [parameter(parametersetname='customendpoint')]
+        [System.Security.Cryptography.X509Certificates.X509Certificate2] $AppCertificate = $null,
 
         [parameter(parametersetname='customendpoint', mandatory=$true)]
         [Uri] $GraphEndpointUri = $null,
@@ -61,15 +76,27 @@ function New-GraphConnection {
         [parameter(parametersetname='msgraph')]
         [parameter(parametersetname='custom')]
         [parameter(parametersetname='customsecret')]
+        [parameter(parametersetname='customcertname')]
+        [parameter(parametersetname='customcert')]
         [parameter(parametersetname='customendpoint')]
         [GraphAuthProtocol] $GraphAuthProtocol = [GraphAuthProtocol]::Default,
 
         [parameter(parametersetname='msgraph')]
         [parameter(parametersetname='custom')]
         [parameter(parametersetname='customsecret')]
+        [parameter(parametersetname='customcertname')]
+        [parameter(parametersetname='customcert')]
         [parameter(parametersetname='customendpoint')]
         [String] $TenantName = $null
     )
+
+    if ( $AppCertificate ) {
+        throw [NotImplementedException]::new("The -AppCertificate option is not yet implemented")
+    }
+
+    if ( $AppCertificatePath ) {
+        throw [NotImplementedException]::new("The -AppCertificatePath option is not yet implemented")
+    }
 
     $validatedCloud = if ( $Cloud ) {
         [GraphCloud] $Cloud
@@ -98,7 +125,15 @@ function New-GraphConnection {
             new-so GraphEndpoint ([GraphCloud]::Custom) ([GraphType]::MSGraph) $GraphEndpointUri $AuthenticationEndpointUri $computedAuthProtocol
         }
 
-        $app = new-so GraphApplication $AppId $AppRedirectUri
+        $secret = if ( $AppSecret ) {
+            $AppSecret
+        } elseif ( $AppCertificate ) {
+            $AppCertificate
+        } else {
+            $AppCertificatePath
+        }
+
+        $app = new-so GraphApplication $AppId $AppRedirectUri $secret
         $identity = new-so GraphIdentity $app $graphEndpoint $TenantName
         new-so GraphConnection $graphEndpoint $identity $ScopeNames
     }

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -113,11 +113,15 @@ function New-GraphConnection {
     $computedAuthProtocol = $::.GraphEndpoint |=> GetAuthProtocol $GraphAuthProtocol $validatedCloud $GraphType
 
     if ( $GraphEndpointUri -eq $null -and $AuthenticationEndpointUri -eq $null -and $specifiedAuthProtocol -and $appId -eq $null ) {
+        write-verbose 'Simple connection specified with no custom uri, auth protocol, or app id'
         $::.GraphConnection |=> NewSimpleConnection $graphType $validatedCloud $specifiedScopes $false $tenantName $computedAuthProtocol
     } else {
         $graphEndpoint = if ( $GraphEndpointUri -eq $null ) {
+            write-verbose 'Custom endpoint data required, no graph endpoint URI was specified, using URI based on cloud'
+            write-verbose ("Creating endpoint with cloud '{0}', auth protocol '{1}'" -f $validatedCloud, $computedAuthProtocol)
             new-so GraphEndpoint $validatedCloud $graphType $null $null $computedAuthProtocol
         } else {
+            write-verbose ("Custom endpoint data required and graph endpoint URI was specified, using specified endpoint URI and auth protocol '0}'" -f $computedAuthProtocol)
             new-so GraphEndpoint ([GraphCloud]::Custom) ([GraphType]::MSGraph) $GraphEndpointUri $AuthenticationEndpointUri $computedAuthProtocol
         }
 

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -52,8 +52,7 @@ function New-GraphConnection {
         [parameter(parametersetname='custom')]
         [parameter(parametersetname='customsecret', mandatory=$true)]
         [parameter(parametersetname='customendpoint')]
-#        [SecureString] $AppSecret = $null,
-        [String] $AppSecret = $null,
+        [SecureString] $AppSecret = $null,
 
         [parameter(parametersetname='msgraph')]
         [parameter(parametersetname='custom')]

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -77,6 +77,8 @@ function New-GraphConnection {
 
         [parameter(parametersetname='msgraph')]
         [parameter(parametersetname='secret')]
+        [parameter(parametersetname='cert')]
+        [parameter(parametersetname='certpath')]
         [parameter(parametersetname='customendpoint')]
         [GraphAuthProtocol] $GraphAuthProtocol = [GraphAuthProtocol]::Default,
 
@@ -93,12 +95,6 @@ function New-GraphConnection {
         ([GraphType]::AADGraph)
     } else {
         ([GraphType]::MSGraph)
-    }
-
-    if ( ($GraphAuthProtocol -eq ([GraphAuthProtocol]::v1)) ) {
-        if ( $Certificate -or $CertificatePath ) {
-            throw 'Certificate options may only be specified for the V2 auth protocol, but v1 was specified'
-        }
     }
 
     $specifiedAuthProtocol = if ( $GraphAuthProtocol -ne ([GraphAuthProtocol]::Default) ) {

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -26,9 +26,6 @@ function New-GraphConnection {
         [parameter(parametersetname='msgraph')]
         [parameter(parametersetname='cloud')]
         [parameter(parametersetname='customendpoint')]
-        [parameter(parametersetname='cert')]
-        [parameter(parametersetname='certpath')]
-        [parameter(parametersetname='secret')]
         [String[]] $ScopeNames = $null,
 
         [parameter(parametersetname='msgraph')]

--- a/src/common/Secret.ps1
+++ b/src/common/Secret.ps1
@@ -86,12 +86,12 @@ ScriptClass Secret {
 
         $currentTime = [DateTime]::Now
 
-        if ( $cert.NotAfter.CompareTo($currentTime) -lt 0 ) {
-            throw [ArgumentException]::new(("The specified certificate '$certDescription' is expired -- current time is '{0}' and the certificate expiration time is '{1}'" -f $currentTime, $cert.NotAfter))
+        if ( $certificate.NotAfter.CompareTo($currentTime) -lt 0 ) {
+            throw [ArgumentException]::new(("The specified certificate '$certDescription' is expired -- current time is '{0}' and the certificate expiration time is '{1}'" -f $currentTime, $certificate.NotAfter))
         }
 
-        if ( $cert.NotBefore.CompareTo($currentTime) -gt 0 ) {
-            write-warning ("Certificate '$certDescription': Current time is {0}, specified certificate is not valid before {1}" -f $currentTime, $cert.NotBefore)
+        if ( $certificate.NotBefore.CompareTo($currentTime) -gt 0 ) {
+            write-warning ("Certificate '$certDescription': Current time is {0}, specified certificate is not valid before {1}" -f $currentTime, $certificate.NotBefore)
         }
     }
 }

--- a/src/common/Secret.ps1
+++ b/src/common/Secret.ps1
@@ -1,0 +1,72 @@
+# Copyright 2018, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+enum SecretType {
+    Certificate
+    Password
+}
+
+ScriptClass Secret {
+    $data = $null
+    $type = $null
+
+    function __initialize($secret) {
+
+        if ( ! $secret ) {
+            throw [ArgumentException]::new('Secret was null or an empty string')
+        }
+
+        if ( $secret -is [SecureString] ) {
+            $this.type = ([SecretType]::Password)
+            $this.data = $secret
+        } else {
+            $this.type = ([SecretType]::Certificate)
+            if ( $secret -is [System.Security.Cryptography.X509Certificates.X509Certificate2] ) {
+                $this.data = $secret
+            } elseif ( $secret -is [string] ) {
+                $certPath = if ( split-path -isabsolutepath $secret ) {
+                    if ( (split-path -qualifier $secret ) -eq 'cert:' ) {
+                        $secret
+                    }
+                    throw [ArgumentException]::new("Path '{0}' was not a valid absolute or relative path in the PowerShell cert: drive")
+                } else {
+                    join-path 'cert:\currentuser\my' $secret
+                }
+
+                $this.data = gi $certPath
+            } else {
+                throw [ArgumentException]::new("Secret was of invalid type '{0}', it must be a [SecureString], [X509Certificate2], or [String] path to a certificate in the PowerShell certificate drive" -f $secret.gettype())
+            }
+        }
+    }
+
+    function GetSecretData {
+        switch ( $this.type ) {
+            ([SecretType]::Certificate) {
+                $this.data
+            }
+            ([SecretType]::Password) {
+                __DecryptSecureString $this.data
+            }
+            default {
+                throw [ArgumentException]::("Unknown secret type '{0}'" -f $this.tostring())
+            }
+        }
+    }
+
+    function __DecryptSecureString( $secureString ) {
+        $pscred = new-object PSCredential '.', $SecureString
+        $pscred.GetNetworkCredential().Password
+    }
+}

--- a/src/common/Secret.ps1
+++ b/src/common/Secret.ps1
@@ -32,10 +32,10 @@ ScriptClass Secret {
             $this.data = $secret
         } else {
             $this.type = ([SecretType]::Certificate)
-            if ( $secret -is [System.Security.Cryptography.X509Certificates.X509Certificate2] ) {
-                $this.data = $secret
+            $certificate = if ( $secret -is [System.Security.Cryptography.X509Certificates.X509Certificate2] ) {
+                $secret
             } elseif ( $secret -is [string] ) {
-                $certPath = if ( split-path -isabsolutepath $secret ) {
+                $certPath = if ( split-path -isabsolute $secret ) {
                     if ( (split-path -qualifier $secret ) -eq 'cert:' ) {
                         $secret
                     }
@@ -44,10 +44,13 @@ ScriptClass Secret {
                     join-path 'cert:\currentuser\my' $secret
                 }
 
-                $this.data = gi $certPath
+                gi $certPath
             } else {
                 throw [ArgumentException]::new("Secret was of invalid type '{0}', it must be a [SecureString], [X509Certificate2], or [String] path to a certificate in the PowerShell certificate drive" -f $secret.gettype())
             }
+
+            __ValidateCertificate $certificate
+            $this.data = $certificate
         }
     }
 
@@ -68,5 +71,27 @@ ScriptClass Secret {
     function __DecryptSecureString( $secureString ) {
         $pscred = new-object PSCredential '.', $SecureString
         $pscred.GetNetworkCredential().Password
+    }
+
+    function __ValidateCertificate( $certificate ) {
+        $certDescription = "thumbprint = {0}, subject = {1}" -f $certificate.thumbprint, $certificate.subject
+        if ( ! $certificate.hasprivatekey ) {
+            throw [ArgumentException]::new("The specified certificate '$certDescription' does not have a private key")
+        }
+
+        if ( ! $certificate.privatekey ) {
+            $knownGoodProviders = @('Microsoft Enhanced RSA and AES Cryptographic Provider', 'Microsoft RSA SChannel Cryptographic Provider') -join "`n"
+            throw [ArgumentException]::new("The specified certificate '$certDescription' is marked as having a private key, but no private key data is available through the [X509Certificate2] type. Try with a new certificate with a different cryptographic provider. If you use the 'New-SelfSignedCertificate' cmdlet, you can specify the provider through the '-provider' option. Providers known to be compatible with the [X509Certificate2] type include and are not limited to the following:`n$knownGoodProviders")
+        }
+
+        $currentTime = [DateTime]::Now
+
+        if ( $cert.NotAfter.CompareTo($currentTime) -lt 0 ) {
+            throw [ArgumentException]::new(("The specified certificate '$certDescription' is expired -- current time is '{0}' and the certificate expiration time is '{1}'" -f $currentTime, $cert.NotAfter))
+        }
+
+        if ( $cert.NotBefore.CompareTo($currentTime) -gt 0 ) {
+            write-warning ("Certificate '$certDescription': Current time is {0}, specified certificate is not valid before {1}" -f $currentTime, $cert.NotBefore)
+        }
     }
 }

--- a/src/graphservice/GraphEndpoint.ps1
+++ b/src/graphservice/GraphEndpoint.ps1
@@ -109,7 +109,11 @@ ScriptClass GraphEndpoint {
         $this.Type = $GraphType
         $this.Cloud = $cloud
         $endpointData = if ($GraphEndpoint -eq $null) {
-            $this.scriptclass |=> GetCloudEndpoint $cloud $graphType
+            $cloudEndpoint = $this.scriptclass |=> GetCloudEndpoint $cloud $graphType
+            if ( $authProtocol ) {
+                $cloudEndpoint.AuthProtocol = $authProtocol
+            }
+            $cloudEndpoint
         } else {
             @{
                 Graph=$GraphEndpoint

--- a/src/graphservice/GraphEndpoint.ps1
+++ b/src/graphservice/GraphEndpoint.ps1
@@ -33,6 +33,14 @@ enum GraphAuthProtocol {
 
 ScriptClass GraphEndpoint {
     static {
+        # Note: this hash table, as well as the nested hash tables,
+        # Must be protected -- do *NOT* give references to them outside
+        # the static methods of this class -- that includes preventing
+        # instance methods from having access! If callers need access to,
+        # the hash tables, clone them. Without that, callers can modify
+        # this shared state! This is an issue for any objects that are not
+        # treated by value. Strings and integers for instance are ok, any
+        # object type is not, and must be handled with care.
         $MSGraphCloudEndpoints = @{
             [GraphCloud]::Public = @{
                 Authentication='https://login.microsoftonline.com'
@@ -63,10 +71,12 @@ ScriptClass GraphEndpoint {
         }
 
         function GetCloudEndpoint([GraphCloud] $cloud, [GraphType] $graphType) {
+            # We *MUST* clone these -- otherwise callers have a reference to the
+            # shared instance in the static class, and they can overwrite it!
             if ($graphType -eq [GraphType]::MSGraph) {
-                $this.MSGraphCloudEndpoints[$cloud]
+                $this.MSGraphCloudEndpoints[$cloud].Clone()
             } else {
-                $this.AADGraphCloudEndpoints
+                $this.AADGraphCloudEndpoints.Clone()
             }
         }
 


### PR DESCRIPTION
### Description

Support for app-only authentication, AAD auth v1 token refresh, defect fixes

### Dependency changes

No dependencies were changed

### Implementation notes

* App-only authentication supporting symmetric secrets and asymmetric PKI via certificates is supported for both v1 and v2 auth protocols
* The app-only support required a refactor of the `AuthProvider` classes
* Added support for v1 token refresh via ADAL required an additional `ClearToken` method for the auth provider classes
* A serious issue with `GraphEndpoint` was fixed where it returned a hash table for cloud endpoints, but the hash table was shared across all instances of `GraphEndpoint`. This led to instance classes overwriting the shared table, which affected other instances and caused non-deterministic behavior particularly for authentication scenarios. A fix was made to always `Clone` the hash table given to callers.

### Checklist

- [X ] All project tests pass successfully
